### PR TITLE
docs(license): add human-readable MIT license summary

### DIFF
--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,39 @@
+# 🏷️ License
+
+Wallet UI is licensed under the MIT License.
+
+---
+
+## 📜 MIT License Summary
+
+- ✅ You can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software  
+- ❌ You cannot hold the original author liable for any damages  
+- ✅ Attribution is required in derivative works
+
+---
+
+## 📄 Full License Text
+
+MIT License
+
+Copyright (c) 2025 Muhammad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction...
+
+[⚠️ Note: Full license text is already in LICENSE file at root]
+
+
+---
+
+## 📁 Related Files
+
+- `LICENSE` → Full legal license  
+- `docs/license.md` → Human-readable summary  
+- `package.json` → `"license": "MIT"`
+
+---
+
+## 📬 License Queries
+
+- GitHub: [Adnanmd76](https://github.com/Adnanmd76)  
+- Email: adnanmd76@gmail.com


### PR DESCRIPTION
🏷️ Add License Summary Documentation

This PR adds `docs/license.md` to explain Wallet UI's MIT license:

- Summary of permissions and limitations  
- Reference to full license file  
- Attribution and liability notes

📌 Branch: docs/license-summary
