### PR TITLE
Add WalletStatus Component to Show Connected Wallet Address

### DIFF
--- a/src/components/WalletStatus.tsx
+++ b/src/components/WalletStatus.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useWallet } from '../web3/hooks';
+
+const WalletStatus: React.FC = () => {
+  const { address, isConnected } = useWallet();
+
+  if (!isConnected) return null;
+
+  return (
+    <div style={{ padding: '8px', backgroundColor: '#f0f0f0', borderRadius: '6px' }}>
+      <strong>Wallet Connected:</strong> {address}
+    </div>
+  );
+};
+
+export default WalletStatus;


### PR DESCRIPTION
This PR adds a simple UI component `WalletStatus` to display the connected wallet address.

🔧 Changes:
- Created `src/components/WalletStatus.tsx`
- Uses `useWallet` hook to show address if connected
- Styled with minimal inline CSS for clarity

📦 Next Steps:
- Extend to show balance and chain ID
- Add disconnect functionality
- Integrate into dashboard or header layout