### PR TITLE
Extend useWallet Hook to Fetch Balance and Chain Info

### DIFF
--- a/src/web3/hooks.ts
+++ b/src/web3/hooks.ts
@@ -1,9 +1,12 @@
 import { useState, useEffect } from 'react';
 import { getProvider } from './provider';
+import { ethers } from 'ethers';
 
 export const useWallet = () => {
   const [address, setAddress] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [balance, setBalance] = useState<string | null>(null);
+  const [chainId, setChainId] = useState<number | null>(null);
 
   useEffect(() => {
     const connectWallet = async () => {
@@ -12,7 +15,12 @@ export const useWallet = () => {
         await provider.send('eth_requestAccounts', []);
         const signer = provider.getSigner();
         const userAddress = await signer.getAddress();
+        const userBalance = await provider.getBalance(userAddress);
+        const network = await provider.getNetwork();
+
         setAddress(userAddress);
+        setBalance(ethers.utils.formatEther(userBalance));
+        setChainId(network.chainId);
         setIsConnected(true);
       } catch (error) {
         console.error('Wallet connection failed:', error);
@@ -23,5 +31,5 @@ export const useWallet = () => {
     connectWallet();
   }, []);
 
-  return { address, isConnected };
+  return { address, isConnected, balance, chainId };
 };


### PR DESCRIPTION
This PR enhances the `useWallet` hook by adding support for fetching wallet balance and chain ID.

🔧 Changes:
- Updated `src/web3/hooks.ts`
- Added `balance` and `chainId` state
- Uses Ethers.js to format balance in ETH

📦 Next Steps:
- Display balance and chain info in WalletStatus component
- Add network switching support
- Handle multi-chain compatibility