### PR TITLE
Add WalletConnect v2 abstraction module in src/web3/walletconnect.ts

### DIFF
--- a/src/web3/walletconnect.ts
+++ b/src/web3/walletconnect.ts
@@ -1,0 +1,24 @@
+import WalletConnectProvider from "@walletconnect/web3-provider";
+import { ethers } from "ethers";
+import { getRpcUrl } from "./provider";
+
+const CHAIN_IDS: Record<string, number> = {
+  ethereum: 1,
+  polygon: 137,
+  bsc: 56,
+  avalanche: 43114,
+  fantom: 250,
+};
+
+export const getWalletConnectProvider = async (
+  chain: string = process.env.NEXT_PUBLIC_DEFAULT_CHAIN || "ethereum"
+): Promise<ethers.providers.Web3Provider> => {
+  const rpcUrl = getRpcUrl(chain);
+  const wcProvider = new WalletConnectProvider({
+    rpc: { [CHAIN_IDS[chain]]: rpcUrl },
+    qrcode: true,
+  });
+
+  await wcProvider.enable();
+  return new ethers.providers.Web3Provider(wcProvider);
+};


### PR DESCRIPTION
This PR introduces a dedicated WalletConnect v2 module:

- Created src/web3/walletconnect.ts  
- Uses @walletconnect/web3-provider to handle QR sessions  
- Reads RPC URLs via existing getRpcUrl helper  
- Exports getWalletConnectProvider for consumption in provider.ts or hooks  

Next steps:
1. Update src/web3/provider.ts to call getWalletConnectProvider when useWalletConnect=true  
2. Extend useWallet hook to accept a `useWalletConnect` flag  
3. Build UI controls for toggling WalletConnect vs injected wallets