### PR TITLE
Refactor provider.ts to use getWalletConnectProvider for v2 support

### DIFF
--- a/src/web3/provider.ts
+++ b/src/web3/provider.ts
@@ -1,53 +1,42 @@
 import { ethers } from 'ethers';
-import WalletConnectProvider from '@walletconnect/web3-provider';
+-import WalletConnectProvider from '@walletconnect/web3-provider';
++import { getWalletConnectProvider } from './walletconnect';
+ import { getRpcUrl } from './provider'; // assuming you still have this helper
 
-const RPC_URLS: Record<string, string> = {
-  ethereum: process.env.NEXT_PUBLIC_ETH_RPC || '',
-  polygon: process.env.NEXT_PUBLIC_POLYGON_RPC || '',
-  bsc: process.env.NEXT_PUBLIC_BSC_RPC || '',
-  avalanche: process.env.NEXT_PUBLIC_AVALANCHE_RPC || '',
-  fantom: process.env.NEXT_PUBLIC_FANTOM_RPC || '',
-};
+ const RPC_URLS: Record<string, string> = { … };
+ const CHAIN_IDS: Record<string, number> = { … };
 
-const CHAIN_IDS: Record<string, number> = {
-  ethereum: 1,
-  polygon: 137,
-  bsc: 56,
-  avalanche: 43114,
-  fantom: 250,
-};
+ export interface ProviderOptions {
+   chain?: string;
+   useWalletConnect?: boolean;
+ }
 
-export interface ProviderOptions {
-  chain?: string;
-  useWalletConnect?: boolean;
-}
+ export const getProvider = async (
+   options: ProviderOptions = {}
+ ): Promise<ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider> => {
+   const chain = options.chain || process.env.NEXT_PUBLIC_DEFAULT_CHAIN || 'ethereum';
+   const rpcUrl = getRpcUrl(chain);
 
-export const getRpcUrl = (chain: string): string => {
-  return RPC_URLS[chain] || process.env.NEXT_PUBLIC_DEFAULT_RPC || '';
-};
+-  // WalletConnect v2 provider inline
+-  if (options.useWalletConnect) {
+-    const wcProvider = new WalletConnectProvider({
+-      rpc: { [CHAIN_IDS[chain]]: rpcUrl },
+-      qrcode: true,
+-    });
+-    await wcProvider.enable();
+-    return new ethers.providers.Web3Provider(wcProvider);
+-  }
++  // 1) WalletConnect v2 via abstraction
++  if (options.useWalletConnect) {
++    return await getWalletConnectProvider(chain);
++  }
 
-export const getProvider = async (
-  options: ProviderOptions = {}
-): Promise<ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider> => {
-  const chain = options.chain || process.env.NEXT_PUBLIC_DEFAULT_CHAIN || 'ethereum';
-  const rpcUrl = getRpcUrl(chain);
+   // 2) Injected browser wallet
+   if (typeof window !== 'undefined' && (window as any).ethereum) {
+     await (window as any).ethereum.request({ method: 'eth_requestAccounts' });
+     return new ethers.providers.Web3Provider((window as any).ethereum);
+   }
 
-  // 1) WalletConnect v2 provider (QR + session)
-  if (options.useWalletConnect) {
-    const wcProvider = new WalletConnectProvider({
-      rpc: { [CHAIN_IDS[chain]]: rpcUrl },
-      qrcode: true,
-    });
-    await wcProvider.enable();
-    return new ethers.providers.Web3Provider(wcProvider);
-  }
-
-  // 2) Injected MetaMask / browser wallet
-  if (typeof window !== 'undefined' && (window as any).ethereum) {
-    await (window as any).ethereum.request({ method: 'eth_requestAccounts' });
-    return new ethers.providers.Web3Provider((window as any).ethereum);
-  }
-
-  // 3) Fallback JSON-RPC
-  return new ethers.providers.JsonRpcProvider(rpcUrl);
-};
+   // 3) Fallback JSON-RPC
+   return new ethers.providers.JsonRpcProvider(rpcUrl);
+ };


### PR DESCRIPTION
This PR refactors src/web3/provider.ts to:

- Import and call getWalletConnectProvider when useWalletConnect=true  
- Remove inline WalletConnectProvider setup  
- Keep injected wallet and JSON-RPC fallback logic unchanged  

Next steps:
1. Update useWallet hook in src/web3/hooks.ts to forward { chain, useWalletConnect }  
2. Build UI controls for toggling WalletConnect vs injected wallets  
3. Implement chain selector & testnet toggle components