### PR TITLE
Add WalletControls component with chain selector and WalletConnect toggle

### DIFF
--- a/src/components/WalletControls.tsx
+++ b/src/components/WalletControls.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { useWallet } from '../web3/hooks';
+
+const chains = ['ethereum', 'polygon', 'bsc', 'avalanche', 'fantom'];
+
+const WalletControls = () => {
+  const [selectedChain, setSelectedChain] = useState('ethereum');
+  const [useWalletConnect, setUseWalletConnect] = useState(false);
+
+  const wallet = useWallet({ chain: selectedChain, useWalletConnect });
+
+  return (
+    <div className="p-4 bg-white dark:bg-gray-900 rounded shadow space-y-4">
+      <div>
+        <label className="block font-semibold mb-1">Select Chain:</label>
+        <select
+          value={selectedChain}
+          onChange={(e) => setSelectedChain(e.target.value)}
+          className="w-full p-2 border rounded"
+        >
+          {chains.map((chain) => (
+            <option key={chain} value={chain}>
+              {chain.toUpperCase()}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={useWalletConnect}
+            onChange={(e) => setUseWalletConnect(e.target.checked)}
+          />
+          <span>Use WalletConnect</span>
+        </label>
+      </div>
+
+      <div className="mt-4 text-sm">
+        {wallet.connected ? (
+          <div>
+            <p><strong>Address:</strong> {wallet.address}</p>
+            <p><strong>Balance:</strong> {wallet.balance} ETH</p>
+            <p><strong>Chain ID:</strong> {wallet.chainId}</p>
+          </div>
+        ) : (
+          <p className="text-red-500">Wallet not connected</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WalletControls;


### PR DESCRIPTION
This PR introduces a new WalletControls component:

- Dropdown to select EVM chain (Ethereum, Polygon, BSC, etc.)  
- Checkbox to toggle WalletConnect v2 usage  
- Displays wallet address, balance, and chain ID  
- Uses enhanced useWallet hook with dynamic options  

Next steps:
1. Integrate WalletControls into dashboard.tsx or HomePage.js  
2. Style for mobile responsiveness  
3. Add testnet/mainnet toggle and RPC health indicator