### PR TITLE
Add NetworkToggle component for mainnet/testnet switch and RPC status

### DIFF
--- a/src/components/NetworkToggle.tsx
+++ b/src/components/NetworkToggle.tsx
@@ -1,0 +1,45 @@
+import React, { useState, useEffect } from 'react';
+
+interface NetworkToggleProps {
+  chain: string;
+  onChange: (network: 'mainnet' | 'testnet') => void;
+}
+
+const NetworkToggle: React.FC<NetworkToggleProps> = ({ chain, onChange }) => {
+  const [network, setNetwork] = useState<'mainnet' | 'testnet'>('mainnet');
+  const [rpcStatus, setRpcStatus] = useState<'online' | 'offline' | 'checking'>('checking');
+
+  useEffect(() => {
+    const checkRpc = async () => {
+      setRpcStatus('checking');
+      try {
+        const url = process.env[`NEXT_PUBLIC_${chain.toUpperCase()}_${network.toUpperCase()}_RPC`];
+        const res = await fetch(url, { method: 'POST', body: '{}' });
+        setRpcStatus(res.ok ? 'online' : 'offline');
+      } catch {
+        setRpcStatus('offline');
+      }
+    };
+
+    checkRpc();
+  }, [chain, network]);
+
+  const handleToggle = () => {
+    const newNetwork = network === 'mainnet' ? 'testnet' : 'mainnet';
+    setNetwork(newNetwork);
+    onChange(newNetwork);
+  };
+
+  return (
+    <div className="flex items-center justify-between p-2 bg-gray-100 dark:bg-gray-800 rounded">
+      <button onClick={handleToggle} className="px-3 py-1 bg-blue-500 text-white rounded">
+        {network === 'mainnet' ? 'Switch to Testnet' : 'Switch to Mainnet'}
+      </button>
+      <span className={`text-sm ${rpcStatus === 'online' ? 'text-green-500' : 'text-red-500'}`}>
+        RPC: {rpcStatus}
+      </span>
+    </div>
+  );
+};
+
+export default NetworkToggle;


### PR DESCRIPTION
This PR introduces a NetworkToggle component:

- Allows switching between mainnet and testnet for any chain  
- Checks RPC endpoint status and displays online/offline indicator  
- Uses environment variables like NEXT_PUBLIC_ETH_MAINNET_RPC and NEXT_PUBLIC_ETH_TESTNET_RPC  

Next steps:
1. Integrate NetworkToggle into WalletControls or dashboard.tsx  
2. Add fallback messaging for offline RPCs  
3. Extend provider.ts to consume selected network type