### PR TITLE
Add network toggle support to provider.ts for mainnet/testnet RPC resolution

### DIFF
--- a/src/web3/provider.ts
+++ b/src/web3/provider.ts
@@ -1,42 +1,26 @@
-import { ethers } from 'ethers';
--import WalletConnectProvider from '@walletconnect/web3-provider';
-+import { getWalletConnectProvider } from './walletconnect';
- import { getRpcUrl } from './provider'; // assuming you still have this helper
+export const getRpcUrl = (
+  chain: string,
+  network: 'mainnet' | 'testnet' = 'mainnet'
+): string => {
+  const key = `NEXT_PUBLIC_${chain.toUpperCase()}_${network.toUpperCase()}_RPC`;
+  return process.env[key] || process.env.NEXT_PUBLIC_DEFAULT_RPC || '';
+};
 
- const RPC_URLS: Record<string, string> = { … };
- const CHAIN_IDS: Record<string, number> = { … };
+export const getProvider = async (
+  options: ProviderOptions & { network?: 'mainnet' | 'testnet' } = {}
+): Promise<ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider> => {
+  const chain = options.chain || process.env.NEXT_PUBLIC_DEFAULT_CHAIN || 'ethereum';
+  const network = options.network || 'mainnet';
+  const rpcUrl = getRpcUrl(chain, network);
 
- export interface ProviderOptions {
-   chain?: string;
-   useWalletConnect?: boolean;
- }
+  if (options.useWalletConnect) {
+    return await getWalletConnectProvider(chain); // optionally pass network too
+  }
 
- export const getProvider = async (
-   options: ProviderOptions = {}
- ): Promise<ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider> => {
-   const chain = options.chain || process.env.NEXT_PUBLIC_DEFAULT_CHAIN || 'ethereum';
-   const rpcUrl = getRpcUrl(chain);
+  if (typeof window !== 'undefined' && (window as any).ethereum) {
+    await (window as any).ethereum.request({ method: 'eth_requestAccounts' });
+    return new ethers.providers.Web3Provider((window as any).ethereum);
+  }
 
--  // WalletConnect v2 provider inline
--  if (options.useWalletConnect) {
--    const wcProvider = new WalletConnectProvider({
--      rpc: { [CHAIN_IDS[chain]]: rpcUrl },
--      qrcode: true,
--    });
--    await wcProvider.enable();
--    return new ethers.providers.Web3Provider(wcProvider);
--  }
-+  // 1) WalletConnect v2 via abstraction
-+  if (options.useWalletConnect) {
-+    return await getWalletConnectProvider(chain);
-+  }
-
-   // 2) Injected browser wallet
-   if (typeof window !== 'undefined' && (window as any).ethereum) {
-     await (window as any).ethereum.request({ method: 'eth_requestAccounts' });
-     return new ethers.providers.Web3Provider((window as any).ethereum);
-   }
-
-   // 3) Fallback JSON-RPC
-   return new ethers.providers.JsonRpcProvider(rpcUrl);
- };
+  return new ethers.providers.JsonRpcProvider(rpcUrl);
+};


### PR DESCRIPTION
This PR enhances provider.ts to:

- Accept a `network` option (mainnet or testnet)  
- Resolve correct RPC URL using getRpcUrl(chain, network)  
- Support dynamic switching between environments via UI  

Next steps:
1. Pass `network` from NetworkToggle to useWallet hook  
2. Add fallback messaging for offline RPCs  
3. Extend WalletConnectProvider to support testnet RPCs