### PR TITLE
Integrate NetworkToggle into WalletControls for dynamic mainnet/testnet switching

### DIFF
--- a/src/components/WalletControls.tsx
+++ b/src/components/WalletControls.tsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
 import { useWallet } from '../web3/hooks';
+import NetworkToggle from './NetworkToggle';
 
 const chains = ['ethereum', 'polygon', 'bsc', 'avalanche', 'fantom'];
 
 const WalletControls = () => {
   const [selectedChain, setSelectedChain] = useState('ethereum');
   const [useWalletConnect, setUseWalletConnect] = useState(false);
+  const [network, setNetwork] = useState<'mainnet' | 'testnet'>('mainnet');
 
-  const wallet = useWallet({ chain: selectedChain, useWalletConnect });
+  const wallet = useWallet({ chain: selectedChain, useWalletConnect, network });
 
   return (
     <div className="p-4 bg-white dark:bg-gray-900 rounded shadow space-y-4">
@@ -36,6 +38,8 @@ const WalletControls = () => {
           <span>Use WalletConnect</span>
         </label>
       </div>
+
+      <NetworkToggle chain={selectedChain} onChange={setNetwork} />
 
       <div className="mt-4 text-sm">
         {wallet.connected ? (


### PR DESCRIPTION
This PR updates WalletControls to:

- Include NetworkToggle component  
- Pass selected `network` to useWallet hook  
- Enable dynamic switching between mainnet and testnet per chain  
- Display updated wallet info accordingly  

Next steps:
1. Add transaction signer modal  
2. Add RPC fallback logic for offline status  
3. Finalize UI polish and mobile responsiveness