### PR TITLE
Add useWallet.ts hook to manage wallet address, balance, and chainId

### DIFF
--- a/src/services/useWallet.ts
+++ b/src/services/useWallet.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { getProvider } from './provider';
+
+interface WalletState {
+  address: string | null;
+  balance: string | null;
+  chainId: number | null;
+  connected: boolean;
+}
+
+interface WalletOptions {
+  chain?: string;
+  network?: 'mainnet' | 'testnet';
+  useWalletConnect?: boolean;
+}
+
+export const useWallet = ({
+  chain = 'ethereum',
+  network = 'mainnet',
+  useWalletConnect = false,
+}: WalletOptions): WalletState => {
+  const [wallet, setWallet] = useState<WalletState>({
+    address: null,
+    balance: null,
+    chainId: null,
+    connected: false,
+  });
+
+  useEffect(() => {
+    const connectWallet = async () => {
+      try {
+        const provider = await getProvider({ chain, network, useWalletConnect });
+        const signer = provider.getSigner();
+        const address = await signer.getAddress();
+        const balance = await provider.getBalance(address);
+        const networkInfo = await provider.getNetwork();
+
+        setWallet({
+          address,
+          balance: balance ? balance.toString() : null,
+          chainId: networkInfo.chainId,
+          connected: true,
+        });
+      } catch (err) {
+        console.error('Wallet connection failed:', err);
+        setWallet((prev) => ({ ...prev, connected: false }));
+      }
+    };
+
+    connectWallet();
+  }, [chain, network, useWalletConnect]);
+
+  return wallet;
+};


### PR DESCRIPTION
This PR adds a missing hook:

- File: src/services/useWallet.ts  
- Uses getProvider to connect wallet  
- Fetches address, balance, and chainId  
- Supports WalletConnect and network toggle  

Next steps:
1. Integrate useWallet into WalletControls.tsx  
2. Display wallet status in WalletStatus.tsx  
3. Add disconnect/reset logic if needed
